### PR TITLE
Please update iscan-plugin-ds-30

### DIFF
--- a/iscan-plugin-ds-30/PKGBUILD
+++ b/iscan-plugin-ds-30/PKGBUILD
@@ -11,13 +11,13 @@ url="http://download.ebz.epson.net/dsc/search/01/search/?OSC=LX"
 license=('custom:AVASYSPL')
 depends=('iscan' 'iscan-data')
 _plugin=${pkgname/iscan-plugin-/}
-_iscan_ver=1.0.1
-_plugin_rel=3
-_file_ver=1.0.0
+_iscan_ver=2.30.4
+_plugin_rel=1
+_file_ver=1.0.1
 source_i686=("https://download2.ebz.epson.net/iscan/plugin/${_plugin}/deb/x86/iscan-${_plugin}-bundle-${_iscan_ver}.x86.deb.tar.gz")
 source_x86_64=("https://download2.ebz.epson.net/iscan/plugin/${_plugin}/deb/x64/iscan-${_plugin}-bundle-${_iscan_ver}.x64.deb.tar.gz")
-sha256sums_i686=('985313174c822e3a17f268684dc31238285282f5f586c1c36ede2ffba3683dfa')
-sha256sums_x86_64=('aa6b2e6406cd24e7bd97a361666910197d94ee72cc93ea13c8b90adc7d61bafa')
+sha256sums_i686=('6524597a243be2fe9ba18183d9e4ddfb7562265a4c2a26ea8489ad355a1bc4de')
+sha256sums_x86_64=('818536ea9631ceaf86acacf04c515bdddffdd3533ad228b78f8b707f60378646')
 install="${pkgname}.install"
 
 if [ "$CARCH" = 'x86_64' ]
@@ -41,12 +41,11 @@ package() {
   # Install plugins
   install -m 755 -d "${pkgdir}/usr/lib/iscan"
   install -m 644 -t "${pkgdir}/usr/lib/iscan" "lib/iscan/lib${pkgname}.so.0.0.0"
-  ln -s "lib${pkgname}.so.0.0.0" "${pkgdir}/usr/lib/iscan/lib${pkgname}.so"
+  ln -s "lib${pkgname}.so.0.0.0" "${pkgdir}/usr/lib/iscaAAn/lib${pkgname}.so"
   ln -s "lib${pkgname}.so.0.0.0" "${pkgdir}/usr/lib/iscan/lib${pkgname}.so.0"
   # Install documentation
   install -m 755 -d "${pkgdir}/usr/share/doc/${pkgname}"
   install -m 644 -t "${pkgdir}/usr/share/doc/${pkgname}" "share/doc/${pkgname}/NEWS"
   # Install licenses
   install -m 755 -d "${pkgdir}/usr/share/licenses/${pkgname}"
-  install -m 644 "share/doc/${pkgname}/AVASYSPL.en.txt" "${pkgdir}/usr/share/licenses/${pkgname}/AVASYSPL"
 }

--- a/iscan-plugin-ds-30/PKGBUILD
+++ b/iscan-plugin-ds-30/PKGBUILD
@@ -41,7 +41,7 @@ package() {
   # Install plugins
   install -m 755 -d "${pkgdir}/usr/lib/iscan"
   install -m 644 -t "${pkgdir}/usr/lib/iscan" "lib/iscan/lib${pkgname}.so.0.0.0"
-  ln -s "lib${pkgname}.so.0.0.0" "${pkgdir}/usr/lib/iscaAAn/lib${pkgname}.so"
+  ln -s "lib${pkgname}.so.0.0.0" "${pkgdir}/usr/lib/iscan/lib${pkgname}.so"
   ln -s "lib${pkgname}.so.0.0.0" "${pkgdir}/usr/lib/iscan/lib${pkgname}.so.0"
   # Install documentation
   install -m 755 -d "${pkgdir}/usr/share/doc/${pkgname}"


### PR DESCRIPTION
Hi,
The current version of this package fails with a 404 error when it tries to download the iscan .deb from Epson. I believe this is related to the current version now being 2.30.4, while the package still tries to download 1.0.1.

I tried to update the pkgbuild myself by changing the versions, but I my pkgbuild fails on this error:
`install: cannot stat 'share/doc/iscan-plugin-ds-30/AVASYSPL.en.txt': No such file or directory`
So I removed line 51 to get around that error, not sure what the issue is. Seems to be some sort of license which I'm sure is necessary, this is as far as I was able to get here.

First pull request btw! haha