### PR TITLE
Support architecture aarch64 for package dbeaver-ce-bin.

### DIFF
--- a/dbeaver-ce-bin/PKGBUILD
+++ b/dbeaver-ce-bin/PKGBUILD
@@ -7,7 +7,7 @@ pkgname=dbeaver-ce-bin
 pkgver=25.0.2
 pkgrel=1
 pkgdesc="Free universal SQL Client for developers and database administrators (community edition)"
-arch=('x86_64')
+arch=('x86_64' 'aarch64')
 url="https://dbeaver.io/"
 license=("Apache-2.0")
 depends=('java-runtime>=17' 'gtk3' 'gtk-update-icon-cache' 'libsecret')

--- a/dbeaver-ce-bin/PKGBUILD
+++ b/dbeaver-ce-bin/PKGBUILD
@@ -13,7 +13,7 @@ license=("Apache-2.0")
 depends=('java-runtime>=17' 'gtk3' 'gtk-update-icon-cache' 'libsecret')
 conflicts=('dbeaver')
 provides=('dbeaver')
-source=("${_pkgname}-${pkgver}.linux.gtk.${arch}-nojdk.tar.gz"::"https://github.com/dbeaver/dbeaver/releases/download/${pkgver}/dbeaver-ce-${pkgver}-linux.gtk.${arch}-nojdk.tar.gz"
+source=("${_pkgname}-${pkgver}.linux.gtk.${CARCH}-nojdk.tar.gz"::"https://github.com/dbeaver/dbeaver/releases/download/${pkgver}/dbeaver-ce-${pkgver}-linux.gtk.${CARCH}-nojdk.tar.gz"
         "io.dbeaver.DBeaver.desktop"
         "${pkgname}.sh"
         "${pkgname}.install")

--- a/dbeaver-ce-bin/PKGBUILD
+++ b/dbeaver-ce-bin/PKGBUILD
@@ -27,13 +27,15 @@ prepare() {
   cd "dbeaver/plugins/com.sun.jna_5.15.0.v20240915-2000/com/sun/jna"
   for _dir in aix-ppc aix-ppc64 darwin-aarch64 darwin-x86-64 \
     dragonflybsd-x86-64 freebsd-aarch64 freebsd-x86 freebsd-x86-64 \
-    linux-aarch64 linux-arm linux-armel linux-loongarch64 linux-mips64el \
+    linux-aarch64 linux-x86-64 linux-arm linux-armel linux-loongarch64 linux-mips64el \
     linux-ppc linux-ppc64le linux-riscv64 linux-s390x linux-x86 \
     openbsd-x86 openbsd-x86-64 \
     sunos-sparc sunos-sparcv9 sunos-x86 sunos-x86-64 \
     win32 win32-aarch64 win32-x86 win32-x86-64
   do
-    rm -r "${_dir}"
+    if [[ "linux-${CARCH//_/-}" != "${_dir}" ]]; then
+      rm -r "${_dir}"
+    fi
   done
 }
 


### PR DESCRIPTION
Besides adding `aarch64` to the `arch` array, only 2 changes were needed:

- Getting the current architecture from `$CARCH`
- Not removing the `linux-aarch64` driver if `$CARCH` is `aarch64`